### PR TITLE
add fontawesome icon set

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -37,7 +37,7 @@ module.exports = configure(function (ctx) {
     extras: [
       // 'ionicons-v4',
       // 'mdi-v5',
-      // 'fontawesome-v5',
+      'fontawesome-v5',
       // 'eva-icons',
       // 'themify',
       // 'line-awesome',


### PR DESCRIPTION
Activate fontawesome icon set in quasar.conf.
See related Merge Request for info screen, which uses a fontawesome icon.